### PR TITLE
cosineSimilarity 함수 성능 개선 및 벡터 정규화 값 사전 계산 도입

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @NaverPayDev/frontend


### PR DESCRIPTION
기존에는 질문과 코드 간의 유사도를 계산할 때마다, 벡터의 길이(norm)를 매번 새로 계산하고 있었습니다. 
이러한 반복 계산을 줄이기 위해, 벡터의 길이(norm) 값을 미리 계산해서 저장하도록 개선합니다. 이렇게 하면 나중에 유사도를 계산할 때 훨씬 빠르고 가볍게 처리할 수 있습니다.

- 벡터 데이터에 norm이라는 새로운 필드를 추가하여, 미리 계산된 길이를 저장합니다.
- 유사도 계산 함수는 이제 norm 값을 인자로 받아 더 효율적으로 계산합니다.
- 임베딩 데이터를 처음 불러올 때, norm 값이 없는 경우 자동으로 계산하여 저장합니다.
- 질문 벡터도 한 번만 계산하여 이후에는 재사용하도록 변경합니다.

보너스 + CODEOWNERS