### PR TITLE
 검색 및 Rerank 과정에 크로스 인코더 점수를 도입

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -141,9 +141,10 @@ export function activate(context: vscode.ExtensionContext) {
               increment: 30,
               message: "관련 코드를 검색 중입니다...",
             });
-            const searchResults = ragService.searchAndRerank(
+            const searchResults = await ragService.searchAndRerank(
               queryVector,
-              userQueryText
+              userQueryText,
+              apiKey
             );
 
             let ragContext =

--- a/src/services/geminiApiService.ts
+++ b/src/services/geminiApiService.ts
@@ -73,3 +73,25 @@ export async function generateAnswer(
     return undefined;
   }
 }
+
+export async function scoreRelevance(
+  apiKey: string,
+  userQuery: string,
+  candidateText: string
+): Promise<number | undefined> {
+  try {
+    const genAI = new GoogleGenerativeAI(apiKey);
+    const model = genAI.getGenerativeModel({ model: GENERATIVE_MODEL_NAME });
+    const prompt = `다음 질문과 코드 스니펫의 관련도를 0과 1 사이의 숫자로만 답해주세요.\n\n질문: ${userQuery}\n\n코드:\n${candidateText}\n`;
+    const result = await model.generateContent(prompt);
+    const text = (await result.response).text().trim();
+    const match = text.match(/\d+(?:\.\d+)?/);
+    if (match) {
+      return parseFloat(match[0]);
+    }
+    return undefined;
+  } catch (error: any) {
+    console.error("[Pie Bot] Gemini 관련도 평가 오류:", error);
+    return undefined;
+  }
+}


### PR DESCRIPTION
- 기존 방식: 질문을 벡터로 변환한 뒤, 미리 저장해둔 코드 벡터들과의 “코사인 유사도”만으로 관련 코드를 찾았습니다.
- 이번 개선: 코사인 유사도 상위 후보 중 일부를 Gemini에게 “이 질문과 이 코드가 얼마나 연관이 있냐”고 직접 물어 0~1 점수를 받습니다. 이 점수를 기존 점수와 섞어 다시 정렬하면, 질문과 더 맞는 코드가 상위에 올 가능성이 높아집니다.
